### PR TITLE
Fix Table of Contents pagination and page breaks

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -89,6 +89,7 @@ function createLatexTemplate() {
   const templatePath = path.join(config.templateDir, 'template.tex');
   
   // Enhanced LaTeX template with better structure and formatting
+  // ADDED: Roman numerals for frontmatter, reset page numbers for mainmatter, clearpage after TOC
   const template = `
 \\documentclass[12pt,a4paper]{book}
 \\usepackage{geometry}
@@ -123,6 +124,14 @@ function createLatexTemplate() {
 \\renewcommand{\\headrulewidth}{0.4pt}
 \\renewcommand{\\footrulewidth}{0pt}
 
+% Title page and TOC page style (no headers/footers)
+\\fancypagestyle{plain}{
+  \\fancyhf{}
+  \\fancyfoot[C]{\\thepage}
+  \\renewcommand{\\headrulewidth}{0pt}
+  \\renewcommand{\\footrulewidth}{0pt}
+}
+
 % Title page customization
 \\makeatletter
 \\def\\maketitle{%
@@ -149,6 +158,9 @@ function createLatexTemplate() {
     \\vfil\\null
   \\end{titlepage}%
   \\setcounter{footnote}{0}%
+  \\setcounter{page}{1}
+  % Roman numerals for front matter
+  \\pagenumbering{roman}
 }
 \\makeatother
 
@@ -160,7 +172,12 @@ $endif$
 
 $if(toc)$
 \\tableofcontents
+\\clearpage  % Ensure content starts on a new page after TOC
 $endif$
+
+% Reset page numbering for main content
+\\pagenumbering{arabic}
+\\setcounter{page}{1}
 
 $body$
 
@@ -196,6 +213,10 @@ function buildBook() {
     output += readMarkdownFile(titlePagePath);
     output += '\n\n\\newpage\n\n';
   }
+  
+  // Add a explicit section break before first chapter to ensure
+  // it starts on a new page after the TOC
+  output += '\\newpage\n\n';
   
   output += '# Rise & Code\n';
   output += '## A Programming Book for Everyone\n\n';


### PR DESCRIPTION
This PR addresses two specific issues with the PDF output format:

## Issues Fixed

1. **Separate TOC Page Numbers**: The Table of Contents now uses Roman numerals (i, ii, iii), while the main content uses Arabic numerals (1, 2, 3). This provides a clear separation between frontmatter and main content.

2. **First Content Page Starts on New Page After TOC**: Added an explicit page break and page counter reset after the Table of Contents to ensure the first chapter always starts on a fresh page.

## Implementation Details

The changes include:

1. Modified the LaTeX template to:
   - Use `\pagenumbering{roman}` for frontmatter (title page, TOC)
   - Add `\clearpage` after the Table of Contents 
   - Reset page numbering with `\pagenumbering{arabic}` for main content
   - Reset page counter with `\setcounter{page}{1}` when main content begins

2. Added an explicit `\newpage` directive before the first chapter content in the generated markdown.

3. Enhanced the "plain" page style to improve the appearance of special pages like the title page and chapter beginnings.

These changes follow standard book formatting conventions where frontmatter (title page, TOC, etc.) uses Roman numerals, and the main content starts with page 1 in Arabic numerals.

## Testing

This has been tested to ensure:
- The title page and TOC use Roman numerals
- The main content starts with page 1
- There is a clean page break between the TOC and first chapter

The changes maintain all the previous improvements to the build process while adding these specific formatting enhancements.