### PR TITLE
Remove HTML link from release notes

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -94,7 +94,7 @@ jobs:
           files: |
             build/rise-and-code.md
             build/rise-and-code.pdf
-            build/rise-and-code.html  # Added HTML file to the release
+            build/rise-and-code.html  # Keep HTML file in the release assets
           body: |
             # Rise & Code Book - ${{ env.VERSION }}
             
@@ -108,7 +108,6 @@ jobs:
             
             - [Complete Book (Markdown)](https://github.com/iksnae/rise-and-code/releases/download/${{ env.VERSION }}/rise-and-code.md)
             - [Complete Book (PDF)](https://github.com/iksnae/rise-and-code/releases/download/${{ env.VERSION }}/rise-and-code.pdf)
-            - [Complete Book (HTML)](https://github.com/iksnae/rise-and-code/releases/download/${{ env.VERSION }}/rise-and-code.html)  # Added HTML link
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This PR removes the HTML link from the release notes while maintaining all the HTML generation and GitHub Pages deployment functionality.

## Changes

1. Removed the HTML link from the release notes body template:
   - Kept the Markdown and PDF download links
   - Removed the line that included the HTML download link

2. Retained all HTML-related functionality:
   - The HTML file is still generated
   - The HTML file is still included in the release assets
   - The HTML file is still deployed to GitHub Pages

## Why This Change?

The HTML link in the release notes was causing confusion or was unnecessary, while the actual HTML file itself is still valuable and being maintained. This change keeps all the functionality intact while cleaning up the release notes.

## Testing

This change can be tested by triggering a new release (either by pushing a change to a markdown file or using the workflow_dispatch trigger). The resulting release notes should only show download links for the Markdown and PDF versions, while the HTML file will still be available in the release assets and deployed to GitHub Pages.