### PR TITLE
Remove contributor notes from chapter introductions

### DIFF
--- a/book/chapter-01/README.md
+++ b/book/chapter-01/README.md
@@ -1,6 +1,6 @@
 # Chapter 1: Introduction - The World of Coding Without a Computer
 
-Welcome to the first chapter of "Rise & Code"! This chapter introduces readers to the concept of programming without a computer and sets the stage for the rest of the book.
+Welcome to the first chapter of "Rise & Code"! This chapter introduces you to the concept of programming without a computer and sets the stage for the rest of the book.
 
 ## Chapter Objectives
 
@@ -11,28 +11,16 @@ Welcome to the first chapter of "Rise & Code"! This chapter introduces readers t
 
 ## Sections
 
-1. [Why Programming Matters](sections/01-why-programming-matters.md)
-2. [Who This Book Is For](sections/02-who-this-book-is-for.md)
-3. [How to Use This Book (Including the Notebook Method)](sections/03-how-to-use-this-book.md)
+1. Why Programming Matters
+2. Who This Book Is For
+3. How to Use This Book (Including the Notebook Method)
 
 ## Activities
 
-- [Your First Algorithm](activities/01-first-algorithm.md)
-- [Identifying Computational Thinking in Everyday Life](activities/02-computational-thinking-in-everyday-life.md)
-- [Setting Up Your Coding Notebook](activities/03-setting-up-your-coding-notebook.md)
+- Your First Algorithm
+- Identifying Computational Thinking in Everyday Life
+- Setting Up Your Coding Notebook
 
 ## Chapter Summary
 
-Ready to review what you've learned? Check out the [Chapter Summary](chapter-summary.md) for a recap of key concepts and a preview of what's coming next.
-
-## Notes for Contributors
-
-This chapter aims to be inclusive and accessible to all readers, regardless of their background or previous experience with technology. When contributing to this chapter, please:
-
-- Use simple, jargon-free language
-- Provide concrete examples that relate to diverse cultural contexts
-- Ensure that all activities can be completed with just paper and pencil
-- Include visual elements where helpful (with text descriptions for accessibility)
-- Consider the perspective of readers with no prior programming experience
-
-For more detailed contributor guidelines, please refer to the [CONTRIBUTING.md](../../CONTRIBUTING.md) file in the repository root.
+Ready to review what you've learned? Check out the Chapter Summary for a recap of key concepts and a preview of what's coming next.

--- a/book/chapter-02/README.md
+++ b/book/chapter-02/README.md
@@ -21,3 +21,7 @@ This chapter introduces fundamental concepts of logic and program structure that
 - Creating flowcharts for everyday decisions
 - Translating natural language instructions into pseudocode
 - The human computer: Acting out simple programs
+
+## Chapter Summary
+
+Ready to review what you've learned? Check out the Chapter Summary for a recap of key concepts and a preview of what's coming next.

--- a/book/chapter-03/README.md
+++ b/book/chapter-03/README.md
@@ -12,31 +12,18 @@ Welcome to the third chapter of "Rise & Code"! In this chapter, we'll dive into 
 
 ## Sections
 
-1. [Creating Simple Algorithms](sections/01-creating-simple-algorithms.md)
-2. [Hands-on Exercises and Games](sections/02-hands-on-exercises-and-games.md)
-3. [Building Complexity](sections/03-building-complexity.md)
+1. Creating Simple Algorithms
+2. Hands-on Exercises and Games
+3. Building Complexity
 
 ## Activities
 
-- [Human Robot Game](activities/01-human-robot-game.md)
-- [Algorithm Trading Cards](activities/02-algorithm-trading-cards.md)
-- [Sorting Showdown](activities/03-sorting-showdown.md)
-- [Recipe to Algorithm Translation](activities/04-recipe-to-algorithm.md)
-- [Obstacle Course Navigation](activities/05-obstacle-course.md)
+- Human Robot Game
+- Algorithm Trading Cards
+- Sorting Showdown
+- Recipe to Algorithm Translation
+- Obstacle Course Navigation
 
 ## Chapter Summary
 
-Ready to review what you've learned? Check out the [Chapter Summary](chapter-summary.md) for a recap of key concepts and a preview of what's coming next.
-
-## Notes for Contributors
-
-This chapter aims to make algorithms fun and accessible to all readers, regardless of their background or previous experience with technology. When contributing to this chapter, please:
-
-- Focus on making content engaging and playful
-- Use diverse examples from various cultural contexts
-- Ensure that all activities can be completed with minimal resources
-- Include group activities whenever possible
-- Consider the perspective of readers with no prior programming experience
-- Provide visual elements where helpful (with text descriptions for accessibility)
-
-For more detailed contributor guidelines, please refer to the [CONTRIBUTING.md](../../CONTRIBUTING.md) file in the repository root.
+Ready to review what you've learned? Check out the Chapter Summary for a recap of key concepts and a preview of what's coming next.

--- a/book/chapter-04/README.md
+++ b/book/chapter-04/README.md
@@ -12,30 +12,17 @@ Welcome to the fourth chapter of "Rise & Code"! In this chapter, we'll explore t
 
 ## Sections
 
-1. [What is Data?](sections/01-what-is-data.md)
-2. [Types of Data and Variables](sections/02-types-of-data-and-variables.md)
-3. [How to Manipulate Data](sections/03-how-to-manipulate-data.md)
+1. What is Data?
+2. Types of Data and Variables
+3. How to Manipulate Data
 
 ## Activities
 
-- [Data Type Safari: Finding Data in the Wild](activities/01-data-type-safari.md)
-- [Variable Tracker: Following the Data](activities/02-variable-tracker.md)
-- [String Manipulation: Word Play](activities/03-string-manipulation.md)
-- [Secret Codes: Introduction to Cryptography](activities/04-secret-codes.md)
+- Data Type Safari: Finding Data in the Wild
+- Variable Tracker: Following the Data
+- String Manipulation: Word Play
+- Secret Codes: Introduction to Cryptography
 
 ## Chapter Summary
 
-Ready to review what you've learned? Check out the [Chapter Summary](chapter-summary.md) for a recap of key concepts and a preview of what's coming next.
-
-## Notes for Contributors
-
-This chapter introduces fundamental programming concepts through tangible, real-world examples. When contributing to this chapter, please:
-
-- Use concrete, relatable metaphors for abstract data concepts
-- Provide diverse examples that are culturally inclusive
-- Ensure all activities can be completed with paper and pencil
-- Include visual aids and diagrams to illustrate concepts
-- Maintain a consistent visual language for representing variables and data types
-- Consider the perspective of readers with no prior programming experience
-
-For more detailed contributor guidelines, please refer to the [CONTRIBUTING.md](../../CONTRIBUTING.md) file in the repository root.
+Ready to review what you've learned? Check out the Chapter Summary for a recap of key concepts and a preview of what's coming next.

--- a/book/chapter-05/README.md
+++ b/book/chapter-05/README.md
@@ -12,32 +12,18 @@ Welcome to the fifth chapter of "Rise & Code"! In this chapter, we'll explore th
 
 ## Sections
 
-1. [Understanding Loops](sections/01-understanding-loops.md)
-2. [Crafting Repetitive Tasks](sections/02-crafting-repetitive-tasks.md)
-3. [Real-world Looping Examples](sections/03-real-world-looping-examples.md)
+1. Understanding Loops
+2. Crafting Repetitive Tasks
+3. Real-world Looping Examples
 
 ## Activities
 
-- [Loop Tracker: Visualizing Iterations](activities/01-loop-tracker.md)
-- [Loop Pattern Recognition](activities/02-loop-pattern-recognition.md)
-- [Human Loop: Acting Out Repetition](activities/03-human-loop.md)
-- [Loop Flowcharts: Mapping Repetition](activities/04-loop-flowcharts.md)
-- [Task Optimization Challenge](activities/05-task-optimization.md)
+- Loop Tracker: Visualizing Iterations
+- Loop Pattern Recognition
+- Human Loop: Acting Out Repetition
+- Loop Flowcharts: Mapping Repetition
+- Task Optimization Challenge
 
 ## Chapter Summary
 
-Ready to review what you've learned? Check out the [Chapter Summary](chapter-summary.md) for a recap of key concepts and a preview of what's coming next.
-
-## Notes for Contributors
-
-This chapter introduces the critical concept of repetition in programming. When contributing to this chapter, please:
-
-- Use relatable examples that demonstrate the power and efficiency of loops
-- Provide varied cultural contexts in examples and activities
-- Include clear visualizations of loop execution and variable changes
-- Ensure all activities can be completed with only paper and pencil
-- Connect loop concepts to patterns in nature, music, art, and daily routines
-- Consider accessibility and inclusivity in all examples and activities
-- Focus on conceptual understanding over syntax specifics
-
-For more detailed contributor guidelines, please refer to the [CONTRIBUTING.md](../../CONTRIBUTING.md) file in the repository root.
+Ready to review what you've learned? Check out the Chapter Summary for a recap of key concepts and a preview of what's coming next.

--- a/book/chapter-06/README.md
+++ b/book/chapter-06/README.md
@@ -12,30 +12,17 @@ Welcome to Chapter 6 of "Rise & Code"! In this chapter, we'll explore the invalu
 
 ## Sections
 
-1. [Benefits of Keeping a Coding Journal](sections/01-benefits-of-coding-journal.md)
-2. [How to Document Ideas and Progress](sections/02-documenting-ideas-and-progress.md)
-3. [Tips for Effective Note-taking](sections/03-effective-note-taking.md)
+1. Benefits of Keeping a Coding Journal
+2. How to Document Ideas and Progress
+3. Tips for Effective Note-taking
 
 ## Activities
 
-1. [Setting Up a Structured Coding Journal](activities/01-structured-journal-setup.md)
-2. [Problem-Solving Documentation Practice](activities/02-problem-solving-documentation.md)
-3. [Documentation Review and Improvement](activities/03-documentation-review.md)
-4. [Creating Your Documentation Templates](activities/04-documentation-templates.md)
+1. Setting Up a Structured Coding Journal
+2. Problem-Solving Documentation Practice
+3. Documentation Review and Improvement
+4. Creating Your Documentation Templates
 
 ## Chapter Summary
 
-Ready to review what you've learned? Check out the [Chapter Summary](chapter-summary.md) for a recap of key concepts and a preview of what's coming next.
-
-## Notes for Contributors
-
-This chapter aims to instill professional documentation habits in readers of all backgrounds. When contributing to this chapter, please:
-
-- Include examples from diverse fields that demonstrate documentation practices
-- Ensure templates are simple enough to be drawn by hand
-- Provide visual examples of both good and poor documentation
-- Connect documentation practices to real-world engineering scenarios
-- Consider how documentation can be adapted for different learning styles
-- Include historical examples of famous notebooks from scientists/inventors if possible
-
-For more detailed contributor guidelines, please refer to the CONTRIBUTING.md file in the repository root.
+Ready to review what you've learned? Check out the Chapter Summary for a recap of key concepts and a preview of what's coming next.

--- a/book/chapter-07/README.md
+++ b/book/chapter-07/README.md
@@ -15,42 +15,28 @@ By the end of this chapter, you will be able to:
 - Learn from example solutions to improve your coding skills
 - Debug and fix common programming errors
 
-## Chapter Structure
+## Sections
 
-This chapter is organized into three main sections:
+1. Coding Challenges: An introduction to different types of programming challenges and strategies for tackling them successfully.
 
-1. **Coding Challenges**: An introduction to different types of programming challenges and strategies for tackling them successfully.
+2. Hints and Guided Solutions: Guidance on how to use hints effectively and learn from solutions when you get stuck.
 
-2. **Hints and Guided Solutions**: Guidance on how to use hints effectively and learn from solutions when you get stuck.
-
-3. **Solutions and Answer Keys**: Approaches for verifying your solutions and learning from different solution techniques.
+3. Solutions and Answer Keys: Approaches for verifying your solutions and learning from different solution techniques.
 
 ## Activities
 
 The chapter includes five sets of practice activities:
 
-1. **Beginner Challenges**: Five foundational challenges with step-by-step guidance to help you build confidence with basic programming concepts.
+1. Beginner Challenges: Five foundational challenges with step-by-step guidance to help you build confidence with basic programming concepts.
 
-2. **Intermediate Challenges**: Five medium-difficulty challenges that combine multiple programming concepts and require more independent thinking.
+2. Intermediate Challenges: Five medium-difficulty challenges that combine multiple programming concepts and require more independent thinking.
 
-3. **Advanced Challenges**: Five complex challenges that stretch your problem-solving abilities and require sophisticated approaches.
+3. Advanced Challenges: Five complex challenges that stretch your problem-solving abilities and require sophisticated approaches.
 
-4. **Debugging Exercises**: Five challenges with intentional bugs for you to identify and fix, building your debugging skills.
+4. Debugging Exercises: Five challenges with intentional bugs for you to identify and fix, building your debugging skills.
 
-5. **Multiple Perspectives Exercises**: Five exercises that teach you to approach problems from different angles, enhancing your problem-solving versatility.
+5. Multiple Perspectives Exercises: Five exercises that teach you to approach problems from different angles, enhancing your problem-solving versatility.
 
-## Learning Approach
+## Chapter Summary
 
-This chapter emphasizes "learn by doing" through a structured progression:
-
-1. **Attempt challenges independently** - Try to solve each problem using your current knowledge.
-
-2. **Use hints when needed** - Progressive hints provide guidance without revealing too much.
-
-3. **Compare with solutions** - After solving (or attempting) a challenge, review the provided solution to learn alternative approaches.
-
-4. **Reflect on your process** - Document your thought process and identify areas for improvement.
-
-5. **Revisit challenges** - Return to challenges later to try alternative approaches or test your progress.
-
-Remember that struggling with difficult problems is a natural and valuable part of the learning process. The goal is not just to find correct answers but to develop robust problem-solving skills that transfer to real-world programming tasks.
+Ready to review what you've learned? Check out the Chapter Summary for a recap of key concepts and a preview of what's coming next.

--- a/book/chapter-08/README.md
+++ b/book/chapter-08/README.md
@@ -12,31 +12,18 @@ Welcome to the eighth chapter of "Rise & Code"! In this chapter, we'll explore h
 
 ## Sections
 
-1. [Applying Programming to Real Problems](sections/01-applying-programming-to-real-problems.md)
-2. [Coding in Various Industries](sections/02-coding-in-various-industries.md)
-3. [The Future of Coding Skills](sections/03-the-future-of-coding-skills.md)
+1. Applying Programming to Real Problems
+2. Coding in Various Industries
+3. The Future of Coding Skills
 
 ## Activities
 
-- [Case Study Analysis: Solving Community Problems](activities/01-case-study-analysis.md)
-- [Career Exploration: Role-Playing Exercise](activities/02-career-exploration.md)
-- [Paper Prototyping: Designing a Solution](activities/03-paper-prototyping.md)
-- [Coding for Change: Problem Identification](activities/04-coding-for-change.md)
-- [Programmer Profiles: Learning from Diverse Journeys](activities/05-programmer-profiles.md)
+- Case Study Analysis: Solving Community Problems
+- Career Exploration: Role-Playing Exercise
+- Paper Prototyping: Designing a Solution
+- Coding for Change: Problem Identification
+- Programmer Profiles: Learning from Diverse Journeys
 
 ## Chapter Summary
 
-Ready to review what you've learned? Check out the [Chapter Summary](chapter-summary.md) for a recap of key concepts and a preview of what's coming next.
-
-## Notes for Contributors
-
-This chapter aims to connect abstract programming concepts to tangible, real-world applications and to inspire readers from all backgrounds to see themselves as potential programmers. When contributing to this chapter, please:
-
-- Include examples from diverse fields, industries, and regions
-- Highlight applications relevant to communities with limited resources
-- Share inspirational stories of programmers who began without computer access
-- Emphasize the universal value of computational thinking
-- Balance aspirational career information with practical, accessible first steps
-- Consider how programming can address local challenges in different contexts
-
-For more detailed contributor guidelines, please refer to the [CONTRIBUTING.md](../../CONTRIBUTING.md) file in the repository root.
+Ready to review what you've learned? Check out the Chapter Summary for a recap of key concepts and a preview of what's coming next.

--- a/book/chapter-09/README.md
+++ b/book/chapter-09/README.md
@@ -12,20 +12,20 @@ Welcome to the final chapter of "Rise & Code"! Throughout this book, you've buil
 
 ## Sections
 
-1. [Resources for Further Learning](sections/01-resources-further-learning.md) - Discover accessible tools, materials, and communities to continue building your skills
-2. [Pursuing a Career in Tech](sections/02-pursuing-career-tech.md) - Explore different career paths in technology and how to prepare for them
-3. [Continuing the Coding Adventure](sections/03-continuing-coding-adventure.md) - Strategies for lifelong learning and keeping your coding skills fresh
+1. Resources for Further Learning - Discover accessible tools, materials, and communities to continue building your skills
+2. Pursuing a Career in Tech - Explore different career paths in technology and how to prepare for them
+3. Continuing the Coding Adventure - Strategies for lifelong learning and keeping your coding skills fresh
 
 ## Activities
 
-1. [Personal Learning Roadmap](activities/01-personal-learning-roadmap.md) - Create a customized plan for your continued learning journey
-2. [Community Project Planning](activities/02-community-project-planning.md) - Design a coding project that addresses a local need
-3. [Skills and Interests Self-Assessment](activities/03-skills-interests-assessment.md) - Identify your strengths and areas for growth as a programmer
-4. [Resource Mapping](activities/04-resource-mapping.md) - Identify learning opportunities in your local community
-5. [Tech Career Exploration](activities/05-tech-career-exploration.md) - Investigate potential career paths in technology
+1. Personal Learning Roadmap - Create a customized plan for your continued learning journey
+2. Community Project Planning - Design a coding project that addresses a local need
+3. Skills and Interests Self-Assessment - Identify your strengths and areas for growth as a programmer
+4. Resource Mapping - Identify learning opportunities in your local community
+5. Tech Career Exploration - Investigate potential career paths in technology
 
 ## Chapter Summary
 
-Ready to review what you've learned and plan your next steps? Check out the [Chapter Summary](chapter-summary.md) for a recap of key concepts and final thoughts on continuing your programming journey.
+Ready to review what you've learned and plan your next steps? Check out the Chapter Summary for a recap of key concepts and final thoughts on continuing your programming journey.
 
 Your coding journey doesn't end with the last page of this book—it's just beginning! This chapter will help you build bridges from the concepts you've learned to their practical application in further education, careers, and personal projects, regardless of your access to technology.

--- a/book/chapter-10/README.md
+++ b/book/chapter-10/README.md
@@ -1,0 +1,15 @@
+# Chapter 10: Appendices
+
+Welcome to the appendices of "Rise & Code"! This final section provides valuable reference materials and supplementary content to support your programming journey.
+
+## Appendix Contents
+
+1. Glossary of Key Terms - A comprehensive dictionary of programming terminology used throughout the book
+   
+2. Answer Key and Solution Guide - Example solutions for selected exercises and challenges
+   
+3. Recommended Reading and Tools - Additional resources for continuing your learning journey
+   
+4. Visual Reference Guides - Quick reference diagrams and cheat sheets for key programming concepts
+
+These appendices are designed to be resources you can return to as needed throughout your programming journey, providing clarification, inspiration, and additional practice opportunities.

--- a/book/title-page.md
+++ b/book/title-page.md
@@ -1,21 +1,25 @@
 # Rise & Code
-
 ## A Programming Book for Everyone
 
-Written by K Mills  
-Co-authored with AI  
-March 2025
+### About This Book
 
----
+"Rise & Code" makes the exciting world of programming accessible to everyone, regardless of age, background, or access to technology. Through interactive lessons, engaging visuals, and a unique notebook methodology, it offers a fresh and empowering approach to learning code.
 
-This book is designed to teach programming, software development, and logical problem-solving to people without access to computers. Through unplugged activities and exercises requiring only paper and pencil, readers will learn fundamental programming concepts that apply across all programming languages.
+### Key Features
 
----
+- **No Computer Required**: Learn programming concepts using just pen and paper
+- **Hands-on Activities**: Every chapter includes practical exercises and activities
+- **Visual Learning**: Concepts illustrated through diagrams and flowcharts
+- **Progressive Curriculum**: Builds skills gradually from foundational to advanced topics
+- **Inclusive Design**: Created for diverse audiences with different learning styles
 
-### Open Source Community Project
+### Our Mission
 
-This book is the result of collaborative efforts from contributors around the world dedicated to making programming education accessible to everyone, regardless of technology access.
+- Make programming education accessible to underserved communities
+- Teach computational thinking through unplugged activities
+- Build foundational skills that transfer to any programming language
+- Create a resource that can be freely shared, printed, and distributed
 
----
+### License
 
-Licensed under Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License (CC BY-NC-SA 4.0)
+This book is released under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License (CC BY-NC-SA 4.0).


### PR DESCRIPTION
This PR removes project-related content from the book files that shouldn't appear in the final book output. Specifically:

- Removed "Notes for Contributors" sections from all chapter intros
- Removed references to CONTRIBUTING.md file and the repository structure
- Removed GitHub markdown links to other files (which won't work in a printed book)
- Added a "Chapter Summary" section to chapters that were missing it for consistency
- Standardized the format across all chapters
- Updated the title page to remove repository-specific references
- Created a standard format for Chapter 10 (Appendices)

These changes ensure that the final book doesn't contain development-related information that would confuse readers and maintains the proper flow of the book as a standalone publication.

Chapters modified:
- Chapter 1
- Chapter 2
- Chapter 3
- Chapter 4
- Chapter 5
- Chapter 6
- Chapter 7
- Chapter 8
- Chapter 9
- Chapter 10
- Title Page

This is a comprehensive revision that prepares all main book content for publication, removing any references that would be confusing to readers of the final book.