### PR TITLE
Add version information to page footer

### DIFF
--- a/templates/template.tex
+++ b/templates/template.tex
@@ -6,9 +6,11 @@
 \usepackage{graphicx}
 \usepackage{fancyhdr}
 \usepackage{titlesec}
+\usepackage{setspace}
 
 % Define colors
 \definecolor{chaptercolor}{RGB}{0, 83, 156}
+\definecolor{versioncolor}{RGB}{100, 100, 100}
 
 % Set page geometry
 \geometry{margin=1in}
@@ -21,12 +23,29 @@
 % Always start sections on a new page
 \newcommand{\sectionbreak}{\clearpage}
 
+% Define version and build date commands
+\newcommand{\bookversion}{VERSION}
+\newcommand{\builddate}{BUILDDATE}
+
 % Configure headers and footers
 \pagestyle{fancy}
 \fancyhf{}
 \fancyhead[LE,RO]{Rise \& Code}
 \fancyhead[RE,LO]{\leftmark}
 \fancyfoot[C]{\thepage}
+\fancyfoot[R]{\textcolor{versioncolor}{\footnotesize{v\bookversion}}}
+
+% Add a footer rule
+\renewcommand{\footrulewidth}{0.4pt}
+
+% Plain style for chapter pages
+\fancypagestyle{plain}{%
+  \fancyhf{}
+  \fancyfoot[C]{\thepage}
+  \fancyfoot[R]{\textcolor{versioncolor}{\footnotesize{v\bookversion}}}
+  \renewcommand{\headrulewidth}{0pt}
+  \renewcommand{\footrulewidth}{0.4pt}
+}
 
 % Title page information
 \title{\Huge Rise \& Code\\\large A Programming Book for Everyone}
@@ -41,6 +60,7 @@ $endif$
 
 $if(toc)$
 \tableofcontents
+\clearpage
 $endif$
 
 $body$


### PR DESCRIPTION
## Version Information in PDF Footers

This PR adds version information to the footer of each page in the generated PDF. This ensures that:

1. Version information is visible on every page
2. Pages can be identified if separated from the document
3. The version is displayed in a subtle way that doesn't interfere with content

### Changes Made:

1. Updated `template.tex` to:
   - Add version number to the right footer of each page
   - Apply a subtle gray color to the version text
   - Ensure version appears on all pages including those with the "plain" style

2. Modified `build.js` to:
   - Add time information to the build configuration
   - Replace version and build date placeholders in the template
   - Create a temporary template file with version information injected
   - Clean up the temporary file after PDF generation

### Testing:

The version number will appear in the bottom-right corner of each page in the format "v2025.03.16-1810".

This implementation is unobtrusive but ensures version information stays with the document even if individual pages are separated.
