### PR TITLE
Fix Spanish PDF generation issue in LaTeX template

### DIFF
--- a/templates/template.tex
+++ b/templates/template.tex
@@ -1,4 +1,3 @@
-
 \documentclass[12pt,a4paper]{book}
 \usepackage{geometry}
 \usepackage{hyperref}
@@ -34,7 +33,7 @@
 
 % Choose title based on language setting
 \newcommand{\booktitle}{%
-  \ifx\langsetting\es
+  \ifx\langsetting es
     \estitle
   \else
     \entitle


### PR DESCRIPTION
This PR fixes the issue with Spanish PDF generation in the LaTeX template that was causing the build to fail.

## Problem
The LaTeX template was using an incorrect conditional syntax to check the language setting. The template was comparing `\langsetting` with `\es`, but `\es` was never defined as a LaTeX command. This caused the conditional check to fail, resulting in the English title always being used regardless of the language setting.

## Solution
Modified the language conditional in `templates/template.tex` to directly compare `\langsetting` with the string literal `es`:

```latex
% Choose title based on language
\newcommand{\booktitle}{%
  \ifx\langsetting es
    \estitle
  \else
    \entitle
  \fi
}
```

This change ensures that when the build script passes `es` as the language setting, the Spanish title "Levántate y Codifica" will be used correctly in the PDF.

## Testing
This fix should restore Spanish PDF generation to working order, as it was in commit `71be63681cd38ed591d20cb412d347383ba91e10`.