### PR TITLE
fix: EPUB image embedding — sections content + book metadata

### DIFF
--- a/book.yaml
+++ b/book.yaml
@@ -1,0 +1,7 @@
+title: "Rise & Code"
+subtitle: "Learn Programming Without a Computer"
+author: "K Mills"
+publisher: "iksnae"
+languages:
+  - en
+  - es


### PR DESCRIPTION
## What

Fixes the long-standing EPUB image embedding issue. Images now appear in the built EPUB.

## Root Cause (fixed upstream in iksnae/book-tools#10)

Three bugs in book-tools prevented images from appearing:

1. **`combine-markdown.sh`** — `find -maxdepth 1` skipped `sections/` subdirectories entirely. All section content (where images live) was excluded from the combined markdown.

2. **`generate-epub.sh`** — Used Perl-style non-greedy regex (`.*?`) that silently fails on both BSD (macOS) and GNU (Linux CI) sed/grep. Image reference extraction returned nothing.

3. **`generate-epub.sh`** — Pandoc was called from project root, but image paths are relative (`images/foo.png`). Without cd'ing to the input file's directory, pandoc couldn't resolve them.

## This PR

- Adds `book.yaml` with correct metadata (title, author, publisher)
- Triggers CI rebuild which will pick up the upstream book-tools fix

## Result

- **Before:** EPUB ~224K (no section content, no images, wrong metadata)
- **After:** EPUB ~2.8MB (55K words, 19 embedded images, correct metadata)

Tested locally on macOS — all images embedded and verified via EPUB extraction.